### PR TITLE
Remove null bytes from logs & fix for logs not being viewable in webpage

### DIFF
--- a/edurange_refactored/user/views.py
+++ b/edurange_refactored/user/views.py
@@ -465,6 +465,11 @@ def scenariosInfo(sId):
 
     players = db_ses.query(User.username).filter(GroupUsers.group_id == StudentGroups.id, StudentGroups.id == gid, GroupUsers.user_id == User.id).all()
 
+    tmp = []
+    for user in players:
+        tmp.append({'username': ''.join(c for c in user.username if c.isalnum())})
+    players = tmp
+
     u_logs = groupCSV(logData, 4)  # Make dictionary using 6th value as key (player name)
 
     return render_template(

--- a/scenarios/global_scripts/analyze.py
+++ b/scenarios/global_scripts/analyze.py
@@ -67,6 +67,7 @@ def get_ttylog_lines_from_file(ttylog, ttylog_seek_pointer):
     ttylog_lines = ttylog_read_data.split('\n')
 
     for line in ttylog_lines:
+        line = line.replace('\x00','')
         if len(line) > 0:
             if line[-1] == '\r':
                 ttylog_lines_file.append(line[:-1])


### PR DESCRIPTION
Fixes #76 
Also includes a fix for the issue where null bytes recorded in a log would cause the command history page to be unviewable by admins/instructors.
The removal of nullbytes was tested/reproduced by logging in as a user and using the command `cat /usr/bin/arch`.


