### PR TITLE
Gateway patch

### DIFF
--- a/scenarios/global_scripts/analyze.py
+++ b/scenarios/global_scripts/analyze.py
@@ -40,7 +40,7 @@ import shutil
 import queue
 import subprocess
 import threading
-from pprint import pprint
+
 def starting_index_timestamp(line):
     """Return the index where the timestamp starts, in a line. If timestamp does not exist, return None"""
     reg_expr_end_timestamp = re.compile(';[0-9]+$')
@@ -115,6 +115,7 @@ def decode(lines, current_user_prompt, current_root_prompt):
         #Eliminiating OSC for root prompt
         if escape_sequence_dict['osc_reg_expr'].findall(line):
             line = escape_sequence_dict['osc_reg_expr'].sub('',line)
+
         #If user prompt or root prompt does not occur at start of prompt, find the position of prompt. Now, The current line will end just before this prompt. A new line is constructed starting from the prompt.
         if (line.casefold().find(current_user_prompt) > 0) or (line.casefold().find(current_root_prompt) > 0):
             if (line.casefold().find(current_user_prompt) > 0):
@@ -765,7 +766,9 @@ if __name__ == "__main__":
         if len(ttylog_lines_to_decode) == 0:
             time.sleep(0.1)
             continue
+
         ttylog_lines = decode(ttylog_lines_to_decode, user_prompt, root_prompt)
+
         for count,line in enumerate(ttylog_lines):
             # Check for ctrl c and remove
             #print("Line ", line)

--- a/scenarios/global_scripts/analyze.py
+++ b/scenarios/global_scripts/analyze.py
@@ -40,8 +40,7 @@ import shutil
 import queue
 import subprocess
 import threading
-
-
+from pprint import pprint
 def starting_index_timestamp(line):
     """Return the index where the timestamp starts, in a line. If timestamp does not exist, return None"""
     reg_expr_end_timestamp = re.compile(';[0-9]+$')
@@ -103,8 +102,8 @@ def decode(lines, current_user_prompt, current_root_prompt):
     buf = []
     i_line = 0
     decode_line_timestamp = ''
-    current_user_prompt = ''
-    current_root_prompt = ''
+    current_user_prompt = current_user_prompt.casefold()
+    current_root_prompt = current_root_prompt.casefold()
 
     for count, line in enumerate(lines):
         i_stream_line = 0
@@ -113,21 +112,9 @@ def decode(lines, current_user_prompt, current_root_prompt):
         encountered_carriage_return = False
         buf.append([])
 
-        p = re.compile(r'^User prompt is ')
-        if p.match(line):
-            current_user_prompt = line.split()[-1]
-            node_name = line.split('@')[-1]
-            current_root_prompt = 'root@' + node_name
-            current_user_prompt = current_user_prompt.casefold()
-            current_root_prompt = current_root_prompt.casefold()
-            buf[i_line] = line
-            i_line += 1
-            continue
-
         #Eliminiating OSC for root prompt
         if escape_sequence_dict['osc_reg_expr'].findall(line):
             line = escape_sequence_dict['osc_reg_expr'].sub('',line)
-
         #If user prompt or root prompt does not occur at start of prompt, find the position of prompt. Now, The current line will end just before this prompt. A new line is constructed starting from the prompt.
         if (line.casefold().find(current_user_prompt) > 0) or (line.casefold().find(current_root_prompt) > 0):
             if (line.casefold().find(current_user_prompt) > 0):
@@ -382,12 +369,12 @@ def get_ttylog_lines_to_decode(ttylog_lines_read_next, ttylog_lines_from_file, k
             index_ttylog_lines_file = len(ttylog_lines_read_next) - 1 - count
 
             # Find the last user prompt. Get data starting from 0th index to ending of last user prompt from the line
-            for p in known_prompts:
-                if (line.casefold().rfind(p) > -1):
-                    line_prompt_end_index = line.casefold().rfind(p)
-                    line_prompt_end_index = line_prompt_end_index + len(p)
-                    break
-            line_to_append = line[:line_prompt_end_index]
+            #for p in known_prompts:
+            #    if (line.casefold().rfind(p.casefold()) > -1):
+            #        line_prompt_end_index = line.casefold().rfind(p.casefold())
+            #        line_prompt_end_index = line_prompt_end_index + len(p.casefold())
+            #        break
+            #line_to_append = line[:line_prompt_end_index]
 
     if index_ttylog_lines_file is not None and no_of_prompts_in_ttylog_read_next >= 2:
 
@@ -395,8 +382,8 @@ def get_ttylog_lines_to_decode(ttylog_lines_read_next, ttylog_lines_from_file, k
 
         # Add the line containing user/root prompt to ttylog_lines_to_decode so that the most recently executed command can be parsed.
         # The characters from 0th index till ending of last user prompt is included is contained in line_to_append
-        if len(line_to_append) > 0:
-            ttylog_lines_to_decode.append(line_to_append)
+        #if len(line_to_append) > 0:
+        #    ttylog_lines_to_decode.append(line_to_append)
 
         ttylog_lines_read_next = ttylog_lines_read_next[index_ttylog_lines_file:]
         return ttylog_lines_to_decode, ttylog_lines_read_next
@@ -698,6 +685,7 @@ if __name__ == "__main__":
     skip_reading_in_first_iteration = True
     ttylog_lines_read_next = []
     exit_flag = False
+    user_prompt = ''
     known_prompts = []
     host_pattern = ''
 
@@ -732,6 +720,7 @@ if __name__ == "__main__":
         p = re.compile(r'^User prompt is ')
         if p.match(line):
             user_initial_prompt = (line.split()[-1])
+            user_prompt = user_initial_prompt
             ttylog_sessions[current_session_id]['initial_prompt'] = user_initial_prompt
             node_name = line.split('@')[-1]
             root_prompt = 'root@' + node_name
@@ -757,8 +746,10 @@ if __name__ == "__main__":
         for node in nodes:
             known_prompts.append(user_initial_prompt.split('@')[0] + '@' + node)
     except FileNotFoundError:
-        print('File /usr/local/src/ttylog/host_names.txt not found', file=sys.stderr)
-        known_prompts.append(user_initial_prompt)
+        user_prompt = user_initial_prompt.split('@')[0] + '@nat'
+        known_prompts.append(user_prompt)
+        known_prompts.append(user_initial_prompt.split('@')[0] + '@FirstStop')
+        host_pattern = "(nat|firststop)"
 
     while True:
 
@@ -774,9 +765,7 @@ if __name__ == "__main__":
         if len(ttylog_lines_to_decode) == 0:
             time.sleep(0.1)
             continue
-
-        ttylog_lines = decode(ttylog_lines_to_decode, user_initial_prompt, root_prompt)
-
+        ttylog_lines = decode(ttylog_lines_to_decode, user_prompt, root_prompt)
         for count,line in enumerate(ttylog_lines):
             # Check for ctrl c and remove
             #print("Line ", line)
@@ -833,7 +822,6 @@ if __name__ == "__main__":
                         line = right_dollar_part[1:]
                 else:
                     current_working_directory = home_directory
-                    user_prompt = user_initial_prompt
                     current_line_prompt = user_prompt
             else:
                 isinput = False


### PR DESCRIPTION
The incorrect prompt value was being passed to the `decode` function.
additionally the decode function immediately set the prompt passed to an empty string so the value didn't matter.

with this change so far i have not been able to reproduce the man page spilling into the input of the next command.
the logic handling the prompt in decode accounts for the case that a prompt is not found at the start of the line, which is something that happens when a user exits a man page.

When `decode` was using the correct prompt, i observed that the output field would always have a prompt appended to the end of it. I was able to solve this by commenting some lines out of the `get_ttylog_lines_to_decode` function.
I'm currently unsure if that was the correct way to solve this.